### PR TITLE
Refactor application reloading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,13 +38,13 @@ COPY requirements.txt .
 RUN pip3 install -r requirements.txt
 
 COPY app /app
+COPY reload.sh /usr/local/sbin/reload-gunicorn
 
 ENTRYPOINT [ \
     "gunicorn", \
     "--bind", "0.0.0.0", \
     "--workers", "4", \
-    "--worker-class", "uvicorn.workers.UvicornWorker", \
-    "--reload" \
+    "--worker-class", "uvicorn.workers.UvicornWorker" \
 ]
 CMD ["hello:app"]
 

--- a/reload.sh
+++ b/reload.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+
+#
+# Trigger reload for all Gunicorn processes
+#
+kill -HUP $(pidof -x gunicorn)


### PR DESCRIPTION
Instead of running Gunicorn always with --reload (which doesn't even work in our setup), provide `/usr/local/sbin/reload-gunicorn` script for reloading all running Gunicorn processes.

This makes it already possible to trigger this script with eg. `docker(-compose) exec <container> /usr/local/sbin/reload-gunicorn`.